### PR TITLE
Feature/multiple harvest accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build/
 .idea
 .in
 google-application-credentials.json
+.vscode
+.editorconfig

--- a/README.md
+++ b/README.md
@@ -192,11 +192,10 @@ You need [Terraform](https://www.terraform.io/) to initialize the cloud resource
 * [Create new project](https://console.cloud.google.com/) in Google Cloud console (or use the one you created when setting up local environment).
 * Enable needed APIs for your project in Google Cloud console: Cloud Functions API, Cloud Key Management Service (KMS) API, Cloud Resource Manager API
 * Create datastore database (in datastore mode) to your region (in Google Cloud console).
-* Download to you computer the Google credentials in JSON format for your project's default service account (GCLOUD_PROJECT_ID@appspot.gserviceaccount.com)
+* Set up and login gcloud CLI tool [Documentation](https://cloud.google.com/sdk/docs/how-to)
 * Make sure the service account has following roles (in Google Cloud Console IAM view): Cloud KMS CryptoKey Encrypter/Decrypter, Editor, Project IAM Admin
 * Define following environment variables:
 ```
-export TF_VAR_gcloud_credentials_path=<path_to_service_account_json_file>
 export TF_VAR_gcloud_project_region=<gcloud_region>
 export TF_VAR_gcloud_project_id=<gcloud_project_id>
 export TF_VAR_gcloud_organisation_id=<gcloud_organisation_id>

--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ export TASK_ID_EXTRA_PAID_LEAVE=13538291
 export TASK_ID_PRODUCT_SERVICE_DEVELOPMENT=14245935
 # Task id for internally invoicable
 export TASK_ID_INTERNALLY_INVOICABLE=14655092
+
+# Comma separate string of Admins slack ids
+export ADMINS=abc123,321cba
+
+# Multiple Harvest accounts as comma separated key values
+export HARVEST_ACCESS_TOKENS=company1:abc123,company2:321cba
+export HARVEST_ACCOUNT_IDS=company1:1234,company2:4321
 ```
 
 ### Running locally

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -2,6 +2,8 @@
   "emailDomains": "ALLOWED_EMAIL_DOMAINS",
   "harvestAccessToken": "HARVEST_ACCESS_TOKEN",
   "harvestAccountId": "HARVEST_ACCOUNT_ID",
+  "harvestAccessTokens": "HARVEST_ACCESS_TOKENS",
+  "harvestAccountIds": "HARVEST_ACCOUNT_IDS",
   "slackBotToken": "SLACK_BOT_TOKEN",
   "slackSigningSecret": "SLACK_SIGNING_SECRET",
   "notifyChannelId": "SLACK_NOTIFY_CHANNEL_ID",
@@ -9,6 +11,7 @@
   "billableStatsColumnHeaders": "BILLABLE_STATS_COLUMN_HEADERS",
   "workingHoursReportHeaders": "WORKING_HOURS_REPORT_COLUMN_HEADERS",
   "sendGridApiKey": "SENDGRID_API_KEY",
+  "admins": "ADMINS",
   "taskIds": {
     "publicHoliday": "TASK_ID_PUBLIC_HOLIDAY",
     "vacation": "TASK_ID_VACATION",

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,7 +1,6 @@
 provider "google" {
-  credentials = "${file("${var.gcloud_credentials_path}")}"
-  region      = "${var.gcloud_project_region}"
-  version     = "~> 3.88"
+  region  = var.gcloud_project_region
+  version = "~> 3.88"
 }
 
 # Project creation manually for now

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,6 +1,3 @@
-variable "gcloud_credentials_path" {
-  type = string
-}
 
 variable "gcloud_project_id" {
   type = string

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -12,7 +12,7 @@ import { version } from '../../package.json';
 export default (config, http) => {
   const logger = log(config);
   const slack = slackApi(config, http);
-  const app = application(config, http, slack);
+
   const { encryptSecret, decryptSecret } = encrypter(config);
 
   const printResponse = (header, msgs) => {
@@ -24,30 +24,34 @@ export default (config, http) => {
 
   const generateStats = async (email, year, month) => {
     logger.info(`Generating stats for ${year}-${month}`);
-    await app.generateStats(year, month, email);
+    await application(config, http, slack).generateStats(year, month, email);
     logger.info(`Sent stats report to ${email}`);
   };
 
-  const generateBillingReports = async (email, year, month, lastNames) => {
+  const generateBillingReports = async (email, year, month, lastNames, opts) => {
     logger.info(`Generating billing reports for ${year}-${month}`);
-    await app.generateBillingReports(year, month, lastNames, email);
+
+    const { harvest } = opts;
+    const harvestAccount = harvest && harvest.match(/^(witted|mavericks)$/g) ? harvest : 'mavericks';
+    await application(config, http, slack, harvestAccount)
+      .generateBillingReports(year, month, lastNames, email);
     logger.info(`Sent billing reports to ${email}`);
   };
 
   const generateWorkingHoursReport = async (email, year, month, range) => {
     logger.info(`Generating working hours report, range ${range} months from ${year}-${month}`);
-    await app.generateWorkingHoursReport(year, month, range, email);
+    await application(config, http, slack).generateWorkingHoursReport(year, month, range, email);
     logger.info(`Sent working hours report to ${email}`);
   };
 
   const sendMonthlyReminders = async (email, year, month) => {
     logger.info(`Sending monthly reminder for ${year}-${month} to ${email}`);
-    await app.sendMonthlyReminders(year, month, email, false);
+    await application(config, http, slack).sendMonthlyReminders(year, month, email, false);
   };
 
-  const calcFlexTime = async (email) => {
+  const calcFlexTime = async (email, harvestAccount = 'mavericks') => {
     logger.info(`Calculating flextime for ${email}`);
-    const data = await app.calcFlextime(email);
+    const data = await application(config, http, slack, harvestAccount).calcFlextime(email);
     printResponse(data.header, data.messages);
   };
 
@@ -62,6 +66,8 @@ export default (config, http) => {
     console.log(`export ALLOWED_EMAIL_DOMAINS=${conf.emailDomains}`);
     console.log(`export HARVEST_ACCESS_TOKEN=${conf.harvestAccessToken}`);
     console.log(`export HARVEST_ACCOUNT_ID=${conf.harvestAccountId}`);
+    console.log(`export HARVEST_ACCESS_TOKENS=${conf.harvestAccessTokens}`);
+    console.log(`export HARVEST_ACCOUNT_IDS=${conf.harvestAccountIds}`);
     console.log(`export SLACK_BOT_TOKEN=${conf.slackBotToken}`);
     console.log(`export SLACK_SIGNING_SECRET=${conf.slackSigningSecret}`);
     console.log(`export SLACK_NOTIFY_CHANNEL_ID=${conf.notifyChannelId}`);
@@ -77,6 +83,7 @@ export default (config, http) => {
     console.log(`export TASK_ID_EXTRA_PAID_LEAVE=${conf.taskIds.extraPaidLeave}`);
     console.log(`export TASK_ID_PRODUCT_SERVICE_DEVELOPMENT=${conf.taskIds.productServiceDevelopment}`);
     console.log(`export TASK_ID_INTERNALLY_INVOICABLE=${conf.taskIds.internallyInvoicable}`);
+    console.log(`export ADMINS=${conf.admins}`);
     /* eslint-enable no-console */
   };
 
@@ -84,23 +91,24 @@ export default (config, http) => {
     program
       .version(version, '-v, --version');
     program
-      .command('stats <email> <year> <month>')
+      .command('stats <email> <year> <month> [harvestAccount]')
       .description('Send monthly statistics to given email address.')
       .action(generateStats);
     program
       .command('report <email> <year> <month> <lastname...>')
+      .option('-a, --harvest <harvestAccount>', 'Harvest account')
       .description('Send monthly reports to given email address for the listed users.')
       .action(generateBillingReports);
     program
-      .command('hours <email> <year> <month> <range>')
+      .command('hours <email> <year> <month> <range> [harvestAccount]')
       .description('Send working hours report to given email address.')
       .action(generateWorkingHoursReport);
     program
-      .command('flextime <email>')
+      .command('flextime <email> [harvestAccount]')
       .description('Calculate flex saldo for given user.')
       .action(calcFlexTime);
     program
-      .command('remind <email> <year> <month>')
+      .command('remind <email> <year> <month> [harvestAccount]')
       .description('Send monthly reminder for given user.')
       .action(sendMonthlyReminders);
     program

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -7,10 +7,10 @@ echo "Set project"
 gcloud --quiet config set project $GCLOUD_PROJECT
 
 echo "Deploy functions"
-gcloud functions deploy initFlextime --set-env-vars GCLOUD_PROJECT=$GCLOUD_PROJECT,FUNCTION_REGION=$FUNCTION_REGION --region=$FUNCTION_REGION --format=none --runtime=nodejs16 --trigger-http
-gcloud functions deploy calcFlextime --set-env-vars GCLOUD_PROJECT=$GCLOUD_PROJECT,FUNCTION_REGION=$FUNCTION_REGION --region=$FUNCTION_REGION --format=none --runtime=nodejs16 --timeout 540 --trigger-topic flextime
-gcloud functions deploy calcStats --set-env-vars GCLOUD_PROJECT=$GCLOUD_PROJECT,FUNCTION_REGION=$FUNCTION_REGION --region=$FUNCTION_REGION --format=none --runtime=nodejs16 --timeout 540 --trigger-topic stats
-gcloud functions deploy calcBillingReports --set-env-vars GCLOUD_PROJECT=$GCLOUD_PROJECT,FUNCTION_REGION=$FUNCTION_REGION --region=$FUNCTION_REGION --format=none --runtime=nodejs16 --timeout 540 --trigger-topic reports
-gcloud functions deploy calcWorkingHours --set-env-vars GCLOUD_PROJECT=$GCLOUD_PROJECT,FUNCTION_REGION=$FUNCTION_REGION --region=$FUNCTION_REGION --format=none --runtime=nodejs16 --timeout 540 --trigger-topic workinghours
-gcloud functions deploy sendReminders --set-env-vars GCLOUD_PROJECT=$GCLOUD_PROJECT,FUNCTION_REGION=$FUNCTION_REGION --region=$FUNCTION_REGION --format=none --runtime=nodejs16 --timeout 540 --trigger-http
-gcloud functions deploy notifyUsers --set-env-vars GCLOUD_PROJECT=$GCLOUD_PROJECT,FUNCTION_REGION=$FUNCTION_REGION --region=$FUNCTION_REGION --format=none --runtime=nodejs16 --trigger-http
+gcloud functions deploy initFlextime --set-env-vars GCLOUD_PROJECT=$GCLOUD_PROJECT,FUNCTION_REGION=$FUNCTION_REGION --region=$FUNCTION_REGION --format=none --runtime=nodejs20 --trigger-http
+gcloud functions deploy calcFlextime --set-env-vars GCLOUD_PROJECT=$GCLOUD_PROJECT,FUNCTION_REGION=$FUNCTION_REGION --region=$FUNCTION_REGION --format=none --runtime=nodejs20 --timeout 540 --trigger-topic flextime
+gcloud functions deploy calcStats --set-env-vars GCLOUD_PROJECT=$GCLOUD_PROJECT,FUNCTION_REGION=$FUNCTION_REGION --region=$FUNCTION_REGION --format=none --runtime=nodejs20 --timeout 540 --trigger-topic stats
+gcloud functions deploy calcBillingReports --set-env-vars GCLOUD_PROJECT=$GCLOUD_PROJECT,FUNCTION_REGION=$FUNCTION_REGION --region=$FUNCTION_REGION --format=none --runtime=nodejs20 --timeout 540 --trigger-topic reports
+gcloud functions deploy calcWorkingHours --set-env-vars GCLOUD_PROJECT=$GCLOUD_PROJECT,FUNCTION_REGION=$FUNCTION_REGION --region=$FUNCTION_REGION --format=none --runtime=nodejs20 --timeout 540 --trigger-topic workinghours
+gcloud functions deploy sendReminders --set-env-vars GCLOUD_PROJECT=$GCLOUD_PROJECT,FUNCTION_REGION=$FUNCTION_REGION --region=$FUNCTION_REGION --format=none --runtime=nodejs20 --timeout 540 --trigger-http
+gcloud functions deploy notifyUsers --set-env-vars GCLOUD_PROJECT=$GCLOUD_PROJECT,FUNCTION_REGION=$FUNCTION_REGION --region=$FUNCTION_REGION --format=none --runtime=nodejs20 --trigger-http


### PR DESCRIPTION
Added support for multiple harvest accounts usage with different keys, resolved from command parameter
Update runtime to node 20
Remove sending reports to Harvest email but use slack profile email instead.
Should be backwards compatible when using only single Harvest account
